### PR TITLE
[Examples] Overrides v2

### DIFF
--- a/cms/faststore/sections.json
+++ b/cms/faststore/sections.json
@@ -54,5 +54,40 @@
         }
       }
     }
+  },
+  {
+    "name": "AlertWithImage",
+    "schema": {
+      "title": "Alert with image",
+      "description": "Add an Alert that has an Image as an icon",
+      "type": "object",
+      "required": ["src", "alt", "content", "dismissible"],
+      "properties": {
+        "src": {
+          "type": "string",
+          "title": "Image source",
+          "description": "Source of the Alert icon image"
+        },
+        "alt": {
+          "type": "string",
+          "title": "Image alt text",
+          "description": "Alt text for the Alert icon image"
+        },
+        "content": { "type": "string", "title": "Content" },
+        "link": {
+          "title": "Link",
+          "type": "object",
+          "properties": {
+            "text": { "type": "string", "title": "Link Text" },
+            "to": { "type": "string", "title": "Action link" }
+          }
+        },
+        "dismissible": {
+          "type": "boolean",
+          "default": false,
+          "title": "Is dismissible?"
+        }
+      }
+    }
   }
 ]

--- a/cms/faststore/sections.json
+++ b/cms/faststore/sections.json
@@ -1,0 +1,58 @@
+[
+  {
+    "name": "CustomIconsAlert",
+    "schema": {
+      "title": "Alert with more Icon options",
+      "description": "Add an alert that has more Icon options",
+      "type": "object",
+      "required": ["icon", "content", "dismissible"],
+      "properties": {
+        "icon": {
+          "type": "string",
+          "title": "Icon",
+          "enumNames": [
+            "Bell",
+            "BellRinging",
+            "Checked",
+            "Info",
+            "Truck",
+            "User",
+            "Storefront"
+          ],
+          "enum": [
+            "Bell",
+            "BellRinging",
+            "Checked",
+            "Info",
+            "Truck",
+            "User",
+            "Storefront"
+          ]
+        },
+        "content": {
+          "type": "string",
+          "title": "Content"
+        },
+        "link": {
+          "title": "Link",
+          "type": "object",
+          "properties": {
+            "text": {
+              "type": "string",
+              "title": "Link Text"
+            },
+            "to": {
+              "type": "string",
+              "title": "Action link"
+            }
+          }
+        },
+        "dismissible": {
+          "type": "boolean",
+          "default": false,
+          "title": "Is dismissible?"
+        }
+      }
+    }
+  }
+]

--- a/faststore.config.js
+++ b/faststore.config.js
@@ -1,23 +1,22 @@
-
 module.exports = {
   seo: {
-  "title": "FastStore",
-  "description": "A fast and performant store framework",
-  "titleTemplate": "%s | FastStore",
-  "author": "FastStore"
-},
+    title: "FastStore",
+    description: "A fast and performant store framework",
+    titleTemplate: "%s | FastStore",
+    author: "FastStore",
+  },
 
   // Theming
-  theme: 'custom-theme',
+  theme: "custom-theme",
 
   // Ecommerce Platform
-  platform: 'vtex',
+  platform: "vtex",
 
   // Platform specific configs for API
   api: {
     storeId: "storeframework",
-    workspace: 'master',
-    environment: 'vtexcommercestable',
+    workspace: "playground",
+    environment: "vtexcommercestable",
     hideUnavailableItems: true,
     incrementAddress: false,
   },
@@ -39,7 +38,7 @@ module.exports = {
   },
 
   cart: {
-    id: '',
+    id: "",
     items: [],
     messages: [],
     shouldSplitItem: true,
@@ -53,7 +52,7 @@ module.exports = {
   accountUrl: "https://secure.vtexfaststore.com/api/io/account",
 
   previewRedirects: {
-    home: '/',
+    home: "/",
     plp: "/office",
     search: "/s?q=Brand",
     pdp: "/awesome-chair/p",
@@ -61,9 +60,9 @@ module.exports = {
 
   // Lighthouse CI
   lighthouse: {
-    server: process.env.BASE_SITE_URL || 'http://localhost:3000',
+    server: process.env.BASE_SITE_URL || "http://localhost:3000",
     pages: {
-      home: '/',
+      home: "/",
       pdp: "/awesome-chair/p",
       collection: "/office",
     },
@@ -72,13 +71,14 @@ module.exports = {
   // E2E CI
   cypress: {
     pages: {
-      home: '/',
+      home: "/",
       pdp: "/awesome-chair/p",
       collection: "/office",
-      collection_filtered: "/office/?category-1=office&brand=Brand&facets=category-1%2Cbrand%27",
+      collection_filtered:
+        "/office/?category-1=office&brand=Brand&facets=category-1%2Cbrand%27",
       search: "/s?q=Brand",
     },
-    browser: 'electron',
+    browser: "electron",
   },
 
   analytics: {
@@ -96,4 +96,4 @@ module.exports = {
       "https://storeframework.myvtex.com/cms-releases/webhook-releases",
     ],
   },
-}
+};

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,0 +1,3 @@
+import CustomIconsAlert from "./sections/CustomIconsAlert/CustomIconsAlert";
+
+export default { CustomIconsAlert };

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,3 +1,8 @@
 import CustomIconsAlert from "./sections/CustomIconsAlert/CustomIconsAlert";
+import AlertWithImage from "./sections/AlertWithImage/AlertWithImage";
 
-export default { CustomIconsAlert };
+const sections = {
+  CustomIconsAlert,
+  AlertWithImage,
+};
+export default sections;

--- a/src/components/sections/AlertWithImage/AlertWithImage.tsx
+++ b/src/components/sections/AlertWithImage/AlertWithImage.tsx
@@ -1,0 +1,44 @@
+import { useMemo } from "react";
+import { AlertSection, getOverriddenSection } from "@faststore/core";
+
+// Image component to display the image (recommended to use this component instead of the native img tag - See Reference)
+import { Image_unstable as Image } from "@faststore/core/experimental";
+
+import styles from "./alert-with-image.module.scss";
+
+interface AlertWithImageProps
+  extends Omit<React.ComponentProps<typeof AlertSection>, "icon"> {
+  src: string;
+  alt: string;
+}
+
+/**
+ * This is an Alert Section override that contains an Image.
+ *
+ * We'll change the CMS schema to add the src option and remove the icon option. (Changes added to sections.json)
+ * Overrides the Icon option and passes down the other props
+ *
+ * It's memoized to avoid being re-created every time the AlertWithImage component is re-rendered
+ */
+
+export default function AlertWithImage(props: AlertWithImageProps) {
+  const { src, alt, ...otherProps } = props;
+
+  const OverriddenAlert = useMemo(
+    () =>
+      getOverriddenSection({
+        Section: AlertSection,
+        className: styles.alertWithImage,
+        components: {
+          Icon: {
+            Component: () => (
+              <Image src={props.src} alt={props.alt} width={24} height={24} />
+            ),
+          },
+        },
+      }),
+    []
+  );
+
+  return <OverriddenAlert {...otherProps} icon="" />;
+}

--- a/src/components/sections/AlertWithImage/alert-with-image.module.scss
+++ b/src/components/sections/AlertWithImage/alert-with-image.module.scss
@@ -1,0 +1,7 @@
+.alertWithImage {
+  [data-fs-image] {
+    width: 24px;
+    height: 24px;
+    margin-right: var(--fs-spacing-1);
+  }
+}

--- a/src/components/sections/CustomIconsAlert/CustomIconsAlert.tsx
+++ b/src/components/sections/CustomIconsAlert/CustomIconsAlert.tsx
@@ -1,0 +1,15 @@
+import { getOverriddenSection, AlertSection } from "@faststore/core";
+
+import styles from "./custom-icons-alert.module.scss";
+
+/**
+ * This is an Alert Section override with custom icon options in the Headless CMS.
+ *
+ * We'll change the schema to include more options for native Icons supported by @faststore/ui.  (Changes added to sections.json)
+ */
+const CustomIconsAlert = getOverriddenSection({
+  Section: AlertSection, // The native section to be overridden (Alert)
+  className: styles.customIconsAlert,
+});
+
+export default CustomIconsAlert;

--- a/src/components/sections/CustomIconsAlert/custom-icons-alert.module.scss
+++ b/src/components/sections/CustomIconsAlert/custom-icons-alert.module.scss
@@ -1,0 +1,12 @@
+.customIconsAlert {
+  [data-fs-alert] {
+    justify-content: center;
+    color: var(--fs-color-neutral-0);
+    background-color: var(--fs-color-neutral-7);
+  }
+
+  [data-fs-icon],
+  [data-fs-link] {
+    color: var(--fs-color-neutral-0);
+  }
+}


### PR DESCRIPTION
## What's the purpose of this pull request?

This PR adds use cases scenarios using [Section Override API v2](https://faststore-site-git-docs-override-version-2-faststore.vercel.app/docs/building-sections/overrides/overrides-overview).

Section override allow you to replace native components within sections with custom ones. This maintains the core functionalities of native components while allowing you to adjust their appearance and behavior to suit your store's needs.

All component customizations happen within sections. You can create multiple overrides for native sections, resulting in a new React component representing the overridden section.

## Examples

### [Use Case 1: Add more icons option to the Alert component](https://faststore-site-git-docs-override-version-2-faststore.vercel.app/docs/building-sections/overrides/use-cases/add-icons-to-the-alert-component)

Common use for [getOverriddenSection](https://faststore-site-git-docs-override-version-2-faststore.vercel.app/docs/building-sections/overrides/specification) in FastStore, focusing on customizing the Headless CMS schema for a section to provide more options.

- We'll create a new component `CustomIconsAlert` 
- Adds custom styles for it.

(Follow the doc guide)
- You can use `playground` [workspace](https://playground--storeframework.myvtex.com/admin/headless-cms/faststore) for testing
- After sync in the CMS, you'll be able to see the new section available
<img width="1347" alt="image" src="https://github.com/vtex-sites/fun-playground.store/assets/3356699/764b0552-f805-4ea4-9b99-87831b997b0f">

- The `CustomIconsAlert` applied locally
<img width="1300" alt="image" src="https://github.com/vtex-sites/fun-playground.store/assets/3356699/82a540b2-8138-4cb9-a739-02135fea685d">

 ______
 
### [Use Case 2: Add an image to your Alert component](https://faststore-site-git-docs-override-version-2-faststore.vercel.app/docs/building-sections/overrides/use-cases/add-an-image-to-your-alert-component)

Display a custom image alongside the text in your alert messages.
The native Alert section provides an icon prop for customization, but you want more control and flexibility over the displayed content.

- We'll create a new component `AlertWithImage` 
- Uses FS `Image` experimental component to better perfomance

(Follow the doc guide)
- You can use `playground` [workspace](https://playground--storeframework.myvtex.com/admin/headless-cms/faststore) for testing
- After sync in the CMS, you'll be able to see the new section available

<img width="1343" alt="image" src="https://github.com/vtex-sites/fun-playground.store/assets/3356699/9d8454b5-f05d-4d17-a859-179aaaa9acce">

- The `AlertWithImage` applied locally
<img width="1305" alt="image" src="https://github.com/vtex-sites/fun-playground.store/assets/3356699/6e53c66a-28c7-48a9-a7a8-1f1bec779982">
